### PR TITLE
Set up Travis for Houston CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+---
+
+language: node_js
+
+node_js:
+  - lts/*
+
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-5-dev
+
+cache:
+  directories:
+    - /tmp/liftoff
+
+matrix:
+  include:
+    - env: DIST=loki
+    - env: DIST=juno
+
+install:
+  - npm install @elementaryos/houston
+
+script:
+  - houston ci
+    --distribution $DIST


### PR DESCRIPTION
See https://medium.com/elementaryos/introducing-houston-ci-3179ec34e726 for more details. This enables continuous integration with the AppCenter Dashboard, so we can be sure builds are passing before we even submit a release.

You will also need to set up Travis CI for this repo at https://travis-ci.org/